### PR TITLE
## v3.8.0 2021-10-15

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -39,3 +39,8 @@
 ## v3.7.2 2021-08-27
 
 * [bug] fix the problem about use-agent-reducer inside ts error.
+
+## v3.8.0 2021-10-15
+
+* [bug] fix the problem about use-agent-reducer includes an inside agent-reducer@3.7.2.
+* [refactor] optimize the dependency mode of `agent-reducer`.

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -39,3 +39,8 @@
 ## v3.7.2 2021-08-27
 
 * [bug] 修复 use-agent-reducer 内部 ts 错误.
+
+## v3.8.0 2021-10-15
+
+* [bug] 修复 use-agent-reducer 内嵌 agent-reducer@3.7.2 的问题。
+* [优化] 更改了 use-agent-reducer 对 agent-reducer 的依赖模式。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "main": "./index.js",
   "author": "Jimmy.Harding",
   "description": "the purpose of this project is make useReducer classify",
@@ -42,9 +42,6 @@
     "react-dom": ">=16.8.0",
     "agent-reducer": ">=3.7.2"
   },
-  "dependencies": {
-    "agent-reducer": "3.7.2"
-  },
   "devDependencies": {
     "@babel/cli": "^7.13.16",
     "@babel/core": "7.2.2",
@@ -70,6 +67,7 @@
     "@typescript-eslint/parser": "4.21.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "agent-reducer": "3.7.2",
     "core-js": "^3.8.0",
     "jest": "^26.0.1",
     "typescript": "^3.8.3",


### PR DESCRIPTION
* [bug] fix the problem about use-agent-reducer includes an inside agent-reducer@3.7.2.
* [refactor] optimize the dependency mode of `agent-reducer`.