### PR TITLE
## v4.1.4 2021-11-23

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -64,4 +64,8 @@
 
 ## v4.1.3 2021-11-23
 
-* [refactor] create API [useWeakSharing](/api?id=useweaksharing)。
+* [refactor] create API [useWeakSharing](/api?id=useweaksharing).
+
+## v4.1.4 2021-11-23
+
+* [bug] fix the API [useModelProvider](/api?id=usemodelprovider) problem, "can not find model" error which is caused by 4.1.3.

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -65,3 +65,7 @@
 ## v4.1.3 2021-11-23
 
 * [新增] 新增 API [useWeakSharing](/zh/api?id=useweaksharing)。
+
+## v4.1.4 2021-11-23
+
+* [bug] 修复由 4.1.3 useWeakSharing 引起的 API [useModelProvider](/api?id=usemodelprovider) "can not find model" 错误问题。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "main": "dist/use-agent-reducer.mini.js",
   "module": "esm/use-agent-reducer.js",
   "typings": "index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ type ContextValue={
 const ModelContext = React.createContext<ContextValue|null>(null);
 
 function recreateWeakSharingModel(model:Model) {
-  return getSharingType(model) === 'weak' ? model : weakSharing(() => model);
+  return getSharingType(model) === 'weak' ? model : weakSharing(() => model).current;
 }
 
 export function useModelProvider(
@@ -174,7 +174,7 @@ export function useModelProvider(
         return { parent, currents: { current: recreateWeakSharingModel(models as Model) } };
       }
       const e = entries.map(([k, v]) => {
-        const { current } = recreateWeakSharingModel(v);
+        const current = recreateWeakSharingModel(v);
         return [k, current];
       });
       const currents = Object.fromEntries(e);


### PR DESCRIPTION
* [bug] fix the API [useModelProvider](/api?id=usemodelprovider) problem, "can not find model" error which is caused by 4.1.3.