### PR TITLE
## v4.1.7 2022-02-14

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -77,3 +77,7 @@
 ## v4.1.6 2022-02-14
 
 * [bug] resolve the problem about the agent methods from parent component can't work in useEffect.
+
+## v4.1.7 2022-02-14
+
+* [bug] resolve the problem about typescript error to `useModel` API, when the param is a class with constructor params.

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -77,3 +77,7 @@
 ## v4.1.6 2022-02-14
 
 * [bug] 修复子组件的 useEffect 中使用父组件 agent 未链接问题。
+
+## v4.1.7 2022-02-14
+
+* [bug] 修复关于 `useModel` API 中使用 Model class 时，class 传参错误问题。

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export declare function useModelProvider(
 ):NamedExoticComponent<{ children?: ReactNode }>;
 
 export declare function useModel<T extends Model>(
-    key: string| number| { new(): T },
+    key: string| number| { new(...args:any[]): T },
 ):T;
 
 export declare function useWeakSharing<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "main": "dist/use-agent-reducer.mini.js",
   "module": "esm/use-agent-reducer.js",
   "typings": "index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ function findModelBy(
 }
 
 export function useModel<T extends Model>(
-  key: string| number| { new(): T },
+  key: string| number| { new(...args:any[]): T },
 ):T {
   const parent = useContext(ModelContext);
   const result = useMemo(() => {


### PR DESCRIPTION
* [bug] resolve the problem about typescript error to `useModel` API, when the param is a class with constructor params.