### PR TITLE
## v4.5.0 2022-05-23

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -93,3 +93,7 @@
 ## v4.3.1 2022-04-25
 
 * [design] add the param defaultModel for API [useModel](/api?id=usemodel)
+
+## v4.5.0 2022-05-23
+
+* [update] use agent-reducer@4.5.0 auto connect feature. And resolve the problem about `weakSharing` switch between two Components can not lead reset.

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -93,3 +93,7 @@
 ## v4.3.1 2022-04-25
 
 * [新增] 为 API [useModel](/zh/api?id=usemodel) 添加第二个参数 defaultModel。
+
+## v4.5.0 2022-05-23
+
+* [update] 使用 agent-reducer@4.5.0 auto connect 特性。并修复使用同一 `weakSharing` 弱共享组件，互切时，无法清理模型状态的问题

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "@types/classnames": "^2.2.7",
     "@types/react": "16.14.21",
     "@types/react-dom": "16.9.14",
-    "agent-reducer": "4.2.3",
+    "agent-reducer": "4.5.0",
     "antd": "^4.16.13",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "4.3.0",
+  "version": "4.5.0",
   "main": "dist/use-agent-reducer.mini.js",
   "module": "esm/use-agent-reducer.js",
   "typings": "index.d.ts",
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "agent-reducer": ">=4.3.0"
+    "agent-reducer": ">=4.5.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",
@@ -88,7 +88,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-test-renderer": "^16.7.0",
-    "agent-reducer": "4.3.0",
+    "agent-reducer": "4.5.0",
     "ts-jest": "^24.0.2",
     "ts-loader": "^6.0.4",
     "tsconfig-paths-webpack-plugin": "^3.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import React, {
   memo, NamedExoticComponent, ReactNode,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -47,11 +48,7 @@ export function useAgentReducer<T extends Model<S>, S>(
     dispatch({ ...action, state: reducer.agent.state });
   };
 
-  if (!initialed) {
-    reducer.connect(dispatcher);
-  }
-
-  useEffect(
+  useLayoutEffect(
     () => {
       if (reducer) {
         reducer.connect(dispatcher);
@@ -117,11 +114,7 @@ export function useAgentSelector<T extends Model<S>, S, R>(
     dispatchRef.current(action);
   };
 
-  if (!initialed) {
-    reducer.connect(dispatchWrap);
-  }
-
-  useEffect(
+  useLayoutEffect(
     () => {
       if (reducer) {
         reducer.connect(dispatchWrap);
@@ -155,11 +148,7 @@ export function useAgentMethods<T extends Model<S>, S>(
 
   const reducer = reducerRef.current as Reducer<S, Action>&ReducerPadding<S, T>;
 
-  if (!initialed) {
-    reducer.connect();
-  }
-
-  useEffect(
+  useLayoutEffect(
     () => {
       if (reducer) {
         reducer.connect();


### PR DESCRIPTION
* [update] use agent-reducer@4.5.0 auto connect feature. And resolve the problem about `weakSharing` switch between two Components can not lead reset.