### PR TITLE
## v4.6.7 2022-11-06

### DIFF
--- a/example/.npmrc
+++ b/example/.npmrc
@@ -1,1 +1,1 @@
-
+registry=https://registry.npmmirror.com

--- a/example/package.json
+++ b/example/package.json
@@ -10,16 +10,16 @@
   },
   "dependencies": {
     "@types/classnames": "^2.2.7",
-    "@types/react": "16.14.21",
-    "@types/react-dom": "16.9.14",
-    "agent-reducer": "^4.6.8",
+    "@types/react": "18.0.25",
+    "@types/react-dom": "18.0.8",
+    "agent-reducer": "^4.6.9",
     "antd": "^4.16.13",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",
     "moment": "^2.24.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "use-agent-reducer": "^4.6.6"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "use-agent-reducer": "^4.6.7"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
@@ -69,7 +69,6 @@
     "prettier-eslint-cli": "^5.0.1",
     "progress-bar-webpack-plugin": "^2.1.0",
     "react-refresh": "^0.14.0",
-    "react-test-renderer": "^16.14.0",
     "regenerator-runtime": "0.13.5",
     "rewire": "5.0.0",
     "style-loader": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "main": "dist/index.js",
   "typings": "index.d.ts",
   "author": "Jimmy.Harding",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,6 @@ import {
   EffectCallback,
 } from 'agent-reducer';
 
-const isDev = process.env.NODE_ENV === 'development';
-
 function toAgentReducer<
     T extends Model<S>, S
     >(reducer:null | AgentReducer<S, T>):AgentReducer<S, T> {
@@ -58,9 +56,6 @@ function useAgent<T extends Model<S>, S>(
 
   const initialed = reducerRef.current !== null;
 
-  const mountRef = useRef(true);
-  mountRef.current = true;
-
   const entryChanged = isEntryChanged<T, S>(entryRef.current, entry);
 
   let oldReducer: AgentReducer<S, T> | null = null;
@@ -92,17 +87,6 @@ function useAgent<T extends Model<S>, S>(
         }
         red.disconnect();
       }
-
-      mountRef.current = false;
-      if (isDev) {
-        setTimeout(() => {
-          if (mountRef.current || !reducerRef.current) {
-            return;
-          }
-          disconnect();
-        });
-        return;
-      }
       disconnect();
     },
     [],
@@ -123,6 +107,10 @@ export function useAgentReducer<T extends Model<S>, S>(
   };
 
   reducer.connect(dispatcher);
+
+  useEffect(() => {
+    reducer.connect(dispatcher);
+  }, []);
 
   return reducer.agent;
 }
@@ -173,6 +161,10 @@ export function useAgentSelector<T extends Model<S>, S, R>(
 
   reducer.connect(dispatchWrap);
 
+  useEffect(() => {
+    reducer.connect(dispatchWrap);
+  }, []);
+
   if (equalityCallback(current, prevRef.current)) {
     return prevRef.current;
   }
@@ -187,6 +179,10 @@ export function useAgentMethods<T extends Model<S>, S>(
   const reducer = useAgent<T, S>(entry, ...middleWares);
 
   reducer.connect();
+
+  useEffect(() => {
+    reducer.connect();
+  }, []);
 
   return reducer.agent;
 }


### PR DESCRIPTION
* [optmize] 优化编译过程，全面支持 ReactRefresh 以及 React 18 React.Strict 严格模式，使用者不再需要使用 webpack resolver alias 配置让 ReactRefresh 生效。