### PR TITLE
## v4.7.0 2022-11-11

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,8 @@
 
 ## useAgentReducer
 
+-> useAgent
+
 This api function is a react hook function, it create a proxy object (`Agent`) by using a model (`Model`), and you can get latest state from `Agent` object, or use its method to change state.
 
 ```typescript
@@ -19,6 +21,17 @@ Be careful, `LifecycleMiddleWare` can not work with this api directly, so, if yo
 You can find how to config an env object [here](/guides?id=about-run-env) and what is `MiddleWare` [here](https://filefoxper.github.io/use-agent-reducer/#/guides?id=middleware).
 
 You can see how to use it [here](/tutorial?id=search-page-model).
+
+## useAgent
+
+It is alias of `useAgentReducer`.
+
+```typescript
+function useAgent<T extends Model<S>, S>(
+    entry: T | { new(): T }, 
+    ...mdws: MiddleWare[]
+): T
+```
 
 ## useMiddleWare
 
@@ -41,10 +54,12 @@ You can see how to use it [here](/tutorial?id=use-middleware).
 
 ## useAgentSelector
 
+-> useSelector (has differences)
+
 This api function is a react hook, it can be used to extract data from a sharing model state. And only the extracted data change can cause its consumer (react component) rerender.
 
 ```typescript
-export declare function useAgentSelector<T extends Model<S>, S, R>(
+export declare function useSelector<T extends Model<S>, S, R>(
     entry: T,
     mapStateCallback: (state: T['state']) => R,
     equalityFn?: (prev: R, current: R) => boolean,
@@ -57,7 +72,21 @@ export declare function useAgentSelector<T extends Model<S>, S, R>(
   
 This function returns data extracted from a model state directly.
 
+## useSelector
+
+The result of `useAgentSelector` only can be changed by model state, but what `useSelector` returns also response the change about the  `mapStateCallback` function, when this function changes, it recomputes a new result, and use `equalityFn` to compare with the old result, if they are different, the return data will be replaced by this new result.
+
+```typescript
+export declare function useAgentSelector<T extends Model<S>, S, R>(
+    entry: T,
+    mapStateCallback: (state: T['state']) => R,
+    equalityFn?: (prev: R, current: R) => boolean,
+): R;
+```
+
 ## useAgentMethods
+
+-> useMethods
 
 This api function is a react hook for calling a model methods. It never causes its consumer (react component) rerendering.
 
@@ -72,6 +101,17 @@ export function useAgentMethods<T extends Model<S>, S>(
 * mdws - optional param, MiddleWares
 
 This function returns a model like instance which has an empty state property. It only provides model methods.
+
+## useMethods
+
+It is alias of `useAgentMethods`.
+
+```typescript
+export function useMethods<T extends Model<S>, S>(
+  entry: T,
+  ...mdws: MiddleWare[],
+): Omit<T, 'state'>
+```
 
 ## shallowEqual
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -125,3 +125,7 @@
 ## v4.6.6 2022-11-06
 
 * [optmize] optmize the build script, support React 18 `React.Strict` and `ReactRefresh` in normal mode.
+
+## v4.7.0 2022-11-11
+
+* [design] create new hooks `useAgent\useMethods\useSelector` to simplify the old hooks `useAgentReducer\useAgentMethods\useAgentSelector`, the old hooks will still be in usage.

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -2,6 +2,8 @@
 
 ## useAgentReducer
 
+-> useAgent
+
 这是一个 react hook 方法，可用于创建一个模型（`Model`）的 [Agent](/zh/introduction?id=模型代理-agent) 代理对象。通过使用该代理对象的方法，可以修改 state 数据。
 
 ```typescript
@@ -19,6 +21,17 @@ function useAgentReducer<T extends Model<S>, S>(
 关于运行环境配置，可参考[此处](/zh/guides?id=关于运行环境配置-runenv)，关于 `MiddleWare` 的定义可参考 `agent-reducer` 文档[关于MiddleWare](https://filefoxper.github.io/agent-reducer/#/zh/guides?id=中间件-middleware)
 
 [使用案例](/zh/tutorial?id=search-page-model)
+
+## useAgent
+
+同 `useAgentReducer`.
+
+```typescript
+function useAgent<T extends Model<S>, S>(
+    entry: T | { new(): T }, 
+    ...mdws: MiddleWare[]
+): T
+```
 
 ## useMiddleWare
 
@@ -41,6 +54,8 @@ function useMiddleWare<T extends Model<S>, S>(
 
 ## useAgentSelector
 
+-> useSelector (has differences)
+
 这是一个 react hook 方法，可用于提取被共享模型 state 中的部分数据，若被提取数据保持不变，则不会触发组件渲染。
 
 ```typescript
@@ -57,7 +72,21 @@ export declare function useAgentSelector<T extends Model<S>, S, R>(
   
 该方法返回值即为被提取数据。
 
+## useSelector
+
+与 `useAgentSelector` 不同的是，该接口不单受到 model state 变化的影响，同时也受到 `mapStateCallback` 回调函数变化的影响，当该回调函数发生改变时会重新计算返回值，并通过 `equalityFn` 对比新老值是否有变化，如果有变化就返回新值。
+
+```typescript
+export declare function useSelector<T extends Model<S>, S, R>(
+    entry: T,
+    mapStateCallback: (state: T['state']) => R,
+    equalityFn?: (prev: R, current: R) => boolean,
+): R;
+```
+
 ## useAgentMethods
+
+-> useMethods
 
 这是一个 react hook 方法，可用于提取被共享模型中的方法，该 hook 本身不会触发当前使用组件渲染。
 
@@ -72,6 +101,17 @@ export function useAgentMethods<T extends Model<S>, S>(
 * mdws - 可选项，想要设置的 MiddleWare 。
 
 该方法返回值为忽略了 state 数据的模型实例。
+
+## useMethods
+
+同 `useAgentMethods`。
+
+```typescript
+export function useMethods<T extends Model<S>, S>(
+  entry: T,
+  ...mdws: MiddleWare[],
+): Omit<T, 'state'>
+```
 
 ## shallowEqual
 

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -125,3 +125,7 @@
 ## v4.6.6 2022-11-06
 
 * [optmize] 优化编译过程，全面支持 ReactRefresh 以及 React 18 React.Strict 严格模式，使用者不再需要使用 webpack resolver alias 配置让 ReactRefresh 生效。
+
+## v4.7.0 2022-11-11
+
+* [design] 在保留原 useAgentReducer\useAgentMethods\useAgentSelector 的基础上增加了功能相同（或相似）的 useAgent\useMethods\useSelector hook 接口，以做调用简化，另外舍弃了原 esm 编译包。

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,10 @@ export declare function useAgentReducer<T extends Model<S>, S>(entry: T | {
     new(): T;
 }, ...middleWares: MiddleWare[]): T;
 
+export declare function useAgent<T extends Model<S>, S>(entry: T | {
+    new(): T;
+}, ...middleWares: MiddleWare[]): T;
+
 export declare function useMiddleWare<T extends Model<S>, S>(
     agent: T,
     ...middleWare: (MiddleWare | LifecycleMiddleWare)[]
@@ -18,7 +22,18 @@ export declare function useAgentSelector<T extends Model<S>, S, R>(
     equalityFn?: (prev: R, current: R) => boolean,
 ): R;
 
+export declare function useSelector<T extends Model<S>, S, R>(
+    entry: T,
+    mapStateCallback: (state: T['state']) => R,
+    equalityFn?: (prev: R, current: R) => boolean,
+): R;
+
 export declare function useAgentMethods<T extends Model<S>, S>(
+    entry: T,
+    ...middleWares: MiddleWare[]
+): Omit<T, 'state'>;
+
+export declare function useMethods<T extends Model<S>, S>(
     entry: T,
     ...middleWares: MiddleWare[]
 ): Omit<T, 'state'>;

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-    module.exports = require('./use-agent-reducer.min.js');
+    module.exports = require('./use-agent-reducer.mini.js');
 } else {
     module.exports = require('./use-agent-reducer.js');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-agent-reducer",
-  "version": "4.6.7",
+  "version": "4.7.0",
   "main": "dist/index.js",
   "typings": "index.d.ts",
   "author": "Jimmy.Harding",


### PR DESCRIPTION
* [design] create new hooks `useAgent\useMethods\useSelector` to simplify the old hooks `useAgentReducer\useAgentMethods\useAgentSelector`, the old hooks will still be in usage.